### PR TITLE
Add Operator install and cleanup

### DIFF
--- a/scripts/cleanup/cleanup-aws.sh
+++ b/scripts/cleanup/cleanup-aws.sh
@@ -17,3 +17,5 @@ aws iam delete-policy \
 aws iam delete-role \
   --role-name ${ROLE_NAME} \
   --region ${EKS_CLUSTER_REGION}
+
+./scripts/cleanup/cleanup-operator.sh

--- a/scripts/cleanup/cleanup-azure.sh
+++ b/scripts/cleanup/cleanup-azure.sh
@@ -13,3 +13,5 @@ humctl delete -f azure-identity-cloudaccount.yaml
 az identity delete \
   --name ${MANAGED_IDENTITY_NAME} \
   --resource-group ${MANAGED_IDENTITY_RESOURCE_GROUP}
+
+./scripts/cleanup/cleanup-operator.sh

--- a/scripts/cleanup/cleanup-gcp.sh
+++ b/scripts/cleanup/cleanup-gcp.sh
@@ -15,3 +15,5 @@ gcloud iam service-accounts delete ${SERVICE_ACCOUNT_NAME}@${GCP_PROJECT_ID}.iam
 
 gcloud iam workload-identity-pools delete ${WIF_POOL_NAME} \
   --location="global" --quiet
+
+./scripts/cleanup/cleanup-operator.sh

--- a/scripts/cleanup/cleanup-generic.sh
+++ b/scripts/cleanup/cleanup-generic.sh
@@ -1,1 +1,1 @@
-echo "Nothing to clean up - done!"
+./scripts/cleanup/cleanup-operator.sh

--- a/scripts/cleanup/cleanup-operator.sh
+++ b/scripts/cleanup/cleanup-operator.sh
@@ -1,0 +1,13 @@
+echo "### Removing the Humanitec Operator"
+
+kubectl delete ns ${SECRETS_NAMESPACE}
+kubectl delete secretstore -n humanitec-operator-system ${SECRET_STORE_ID}
+
+humctl api delete /orgs/${HUMANITEC_ORG}/keys/${OPERATOR_PUBLIC_KEY_ID}
+rm humanitec_operator_private_key.pem
+rm humanitec_operator_public_key.pem
+
+helm uninstall humanitec-operator \
+  --namespace humanitec-operator-system
+
+kubectl delete ns humanitec-operator-system

--- a/scripts/connect-your-cluster/install-operator.sh
+++ b/scripts/connect-your-cluster/install-operator.sh
@@ -1,0 +1,55 @@
+# These steps reiterate the commands seen at https://developer.humanitec.com/integration-and-extensions/humanitec-operator/installation/
+
+set -eo pipefail
+
+###
+# Install the latest version
+###
+echo "### Installing the Humanitec Operator to your cluster"
+helm install humanitec-operator \
+  oci://ghcr.io/humanitec/charts/humanitec-operator \
+  --namespace humanitec-operator-system \
+  --create-namespace
+
+###
+# Configure authentication for Drivers
+####
+echo "### Preparing a key pair for the Operator"
+# Generate a new private key
+openssl genpkey -algorithm RSA -out humanitec_operator_private_key.pem -pkeyopt rsa_keygen_bits:4096
+# Extract the public key from the private key generated in the previous command
+openssl rsa -in humanitec_operator_private_key.pem -outform PEM -pubout -out humanitec_operator_public_key.pem
+
+# Add a Secret to the Humanitec Operator 
+kubectl --namespace humanitec-operator-system create secret generic humanitec-operator-private-key \
+     --from-file=privateKey=humanitec_operator_private_key.pem \
+     --from-literal=humanitecOrganisationID=$HUMANITEC_ORG
+
+# Register the public key with the Humanitec Platform Orchestrator
+echo "### Registering the Operator public key with the Platform Orchestrator"
+export OPERATOR_PUBLIC_KEY_ID=$(humctl api post /orgs/${HUMANITEC_ORG}/keys \
+  -d "$(cat humanitec_operator_public_key.pem | jq -sR)" \
+  | jq .id | tr -d "\"")
+
+###
+# Configure the Kubernetes secret store to use for the Operator
+###
+echo "### Configuring the Kubernetes secret store to use for the Operator"
+
+export SECRET_STORE_ID=quickstart-k8s-store
+export SECRETS_NAMESPACE=quickstart-secrets
+
+kubectl apply -f - << EOF
+apiVersion: humanitec.io/v1alpha1
+kind: SecretStore
+metadata:
+  name: ${SECRET_STORE_ID}
+  namespace: humanitec-operator-system
+  labels:
+    app.humanitec.io/default-store: "true"
+spec:
+  kubernetes:
+    namespace: ${SECRETS_NAMESPACE}
+EOF
+
+kubectl create ns ${SECRETS_NAMESPACE}


### PR DESCRIPTION
This PR adds the installation and cleanup steps for the Humanitec Operator. With Legacy mode being deprecated, it becomes a must-have to perform any deployments.

The PR should be merged in tandem with https://github.com/humanitec/developers-docs/pull/964.