### PR TITLE
Switch to aws-identity

### DIFF
--- a/scripts/cleanup/cleanup-aws.sh
+++ b/scripts/cleanup/cleanup-aws.sh
@@ -3,7 +3,7 @@ aws eks delete-access-entry \
   --principal-arn ${ROLE_ARN} \
   --region ${EKS_CLUSTER_REGION}
 
-humctl delete -f aws-role-cloudaccount.yaml
+humctl delete -f aws-identity-cloudaccount.yaml
 
 aws iam detach-role-policy \
   --role-name ${ROLE_NAME} \

--- a/scripts/connect-your-cluster/cloudaccount-aws.sh
+++ b/scripts/connect-your-cluster/cloudaccount-aws.sh
@@ -1,9 +1,16 @@
 # These steps reiterate the commands seen at https://developer.humanitec.com/platform-orchestrator/security/cloud-accounts/aws/
 
-# Create a non-guessable ExternalId that will uniquely identify the Cloud Account in the Humanitec Platform Orchestrator.
-export EXTERNAL_ID=$(uuidgen)
+# Define the name and id of the new Cloud Account
+export CLOUD_ACCOUNT_NAME="Quickstart AWS"
+export CLOUD_ACCOUNT_ID=quickstart-aws
 
-# Create an IAM role to establish a trust relationship between your trusting account and the public Humanitec AWS user
+# Create an IAM OpenID Connect (OIDC) Identity Provider trusting the Humanitec issuer, and capture its ARN
+export OIDC_PROVIDER_ARN=$(aws iam create-open-id-connect-provider \
+  --url https://idtoken.humanitec.io \
+  --client-id-list sts.amazonaws.com \
+  --query OpenIDConnectProviderArn --output text)
+
+# Create an IAM role for Web Identity Federation via OIDC
 cat <<EOF > trust-policy.json
 {
   "Version": "2012-10-17",
@@ -11,12 +18,13 @@ cat <<EOF > trust-policy.json
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "arn:aws:iam::360308478938:user/humanitec"
+        "Federated": "${OIDC_PROVIDER_ARN}"
       },
-      "Action": "sts:AssumeRole",
+      "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "sts:ExternalId": "${EXTERNAL_ID}"
+          "idtoken.humanitec.io:sub": "${HUMANITEC_ORG}/${CLOUD_ACCOUNT_ID}",
+          "idtoken.humanitec.io:aud": "sts.amazonaws.com"
         }
       }
     }
@@ -30,26 +38,22 @@ export ROLE_NAME=quickstart-aws-cloudaccount
 # Create the IAM role including the trust policy and capture its ARN
 export ROLE_ARN=$(aws iam create-role --role-name ${ROLE_NAME} \
   --assume-role-policy-document file://trust-policy.json \
-  | jq .Role.Arn | tr -d "\"")
+  | jq -r .Role.Arn )
 echo ${ROLE_ARN}
 
-# Define the name and id of the new Cloud Account
-export CLOUD_ACCOUNT_NAME="Quickstart AWS"
-export CLOUD_ACCOUNT_ID=quickstart-aws
 
 # Create a file defining the Cloud Account you want to create
-cat << EOF > aws-role-cloudaccount.yaml
+cat << EOF > aws-identity-cloudaccount.yaml
 apiVersion: entity.humanitec.io/v1b1
 kind: Account
 metadata:
   id: ${CLOUD_ACCOUNT_ID}
 entity:
   name: ${CLOUD_ACCOUNT_NAME}
-  type: aws-role
+  type: aws-identity
   credentials:
-    aws_role: ${ROLE_ARN}
-    external_id: ${EXTERNAL_ID}
+    aws_identity_role_arn: ${ROLE_ARN}
 EOF
 
 # Use the humctl create command to create the Cloud Account
-humctl apply -f aws-role-cloudaccount.yaml
+humctl apply -f aws-identity-cloudaccount.yaml

--- a/scripts/connect-your-cluster/create-resdef-aws.sh
+++ b/scripts/connect-your-cluster/create-resdef-aws.sh
@@ -8,7 +8,7 @@ metadata:
 entity:
   name: ${CLOUD}-quickstart
   type: k8s-cluster
-  # The driver_account references a Cloud Account of type "aws-role"
+  # The driver_account references a Cloud Account of type "aws-identity"
   # which needs to be configured for your Organization.
   driver_account: ${CLOUD_ACCOUNT_ID}
   driver_type: humanitec/k8s-cluster-eks


### PR DESCRIPTION
This PR switches the tutorial backing content for the [Quickstart Guide](https://developer.humanitec.com/app-humanitec-io/guides/getting-started/quickstart/connect-your-cluster/) from the deprecated `aws-role` to the newer `aws-identity` Cloud Account type.